### PR TITLE
bump memory limit

### DIFF
--- a/common/memory.h
+++ b/common/memory.h
@@ -40,10 +40,12 @@
 extern "C" {
 #endif
 
-/* Note that 128 MiB is an arbitrary selected upper limit here
+/* We bumped this value from 128MiB, due to this bug:
+   https://podio.com/easyesicom/feature-roadmap/apps/bugs/items/17191
+   The 128MiB limit was rather arbitrary, so we set it back to it's old value, INT32_MAX
  */
 #define MEMORY_MAXIMUM_ALLOCATION_SIZE \
-	( 128 * 1024 * 1024 )
+	INT32_MAX
 
 /* Memory allocation
  */


### PR DESCRIPTION
Increased the memory limit on our fork of libpff to INT_MAX32 (the value it was previously before the recent update).
The current limit seems to be arbitrary according to this code comment

Hard to know if there will be consequences for this limit bump, but for now we certainly need to allow clients to upload PSTs.

Aha, Podio Bug or Trello Card Link:
https://podio.com/easyesicom/feature-roadmap/apps/bugs/items/17191?utm_campaign=member_reference_add&utm_medium=email&utm_source=email_content

Testing Procedure or Link:
Tested this on a client's larger PST file that was not getting extracted correctly on the live site.

Release Related Information (e.g. Migrations or Major Architectural Changes):
n/a

Security Review (e.g. link to SIA or brief explanation of how this does/doesn't impact security)
See feature design document or contact S&C for ideas on what to consider
Request review from @Everlaw/securityanalysts if review is required
n/a