### PR TITLE
Bugfix/two pst fixes

### DIFF
--- a/libpff/libpff_local_descriptors.c
+++ b/libpff/libpff_local_descriptors.c
@@ -371,6 +371,7 @@ int libpff_local_descriptors_get_leaf_node_from_node_by_identifier(
 	{
 		return( 0 );
 	}
+    result = 0;
 	if( offsets_index_value == NULL )
 	{
 		libcerror_error_set(

--- a/libpff/libpff_name_to_id_map.c
+++ b/libpff/libpff_name_to_id_map.c
@@ -365,41 +365,34 @@ int libpff_name_to_id_map_read(
 
 		goto on_error;
 	}
-	if( name_to_id_map_entries_data == NULL )
+	if( name_to_id_map_entries_data == NULL || name_to_id_map_entries_data_size == 0)
 	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
-		 LIBCERROR_RUNTIME_ERROR_VALUE_MISSING,
-		 "%s: missing name to id map entries data.",
-		 function );
+	    number_of_name_to_id_map_entries = 0;
+	} else {
+        if(( name_to_id_map_entries_data_size > (size_t) SSIZE_MAX ) )
+        {
+            libcerror_error_set(
+             error,
+             LIBCERROR_ERROR_DOMAIN_RUNTIME,
+             LIBCERROR_RUNTIME_ERROR_VALUE_OUT_OF_BOUNDS,
+             "%s: invalid name to id map entries data size value out of bounds.",
+             function );
 
-		goto on_error;
-	}
-	if( ( name_to_id_map_entries_data_size == 0 )
-	 || ( name_to_id_map_entries_data_size > (size_t) SSIZE_MAX ) )
-	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
-		 LIBCERROR_RUNTIME_ERROR_VALUE_OUT_OF_BOUNDS,
-		 "%s: invalid name to id map entries data size value out of bounds.",
-		 function );
+            goto on_error;
+        }
+        if( ( name_to_id_map_entries_data_size % 8 ) != 0 )
+        {
+            libcerror_error_set(
+             error,
+             LIBCERROR_ERROR_DOMAIN_RUNTIME,
+             LIBCERROR_RUNTIME_ERROR_UNSUPPORTED_VALUE,
+             "%s: unsupported name to id map entries size.",
+             function );
 
-		goto on_error;
-	}
-	if( ( name_to_id_map_entries_data_size % 8 ) != 0 )
-	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
-		 LIBCERROR_RUNTIME_ERROR_UNSUPPORTED_VALUE,
-		 "%s: unsupported name to id map entries size.",
-		 function );
-
-		goto on_error;
-	}
-	number_of_name_to_id_map_entries = (uint32_t) ( name_to_id_map_entries_data_size / 8 );
+            goto on_error;
+        }
+        number_of_name_to_id_map_entries = (uint32_t) ( name_to_id_map_entries_data_size / 8 );
+    }
 
 	if( libpff_table_get_record_entry_by_type(
 	     item_values->table,

--- a/libpff/libpff_name_to_id_map.c
+++ b/libpff/libpff_name_to_id_map.c
@@ -445,19 +445,7 @@ int libpff_name_to_id_map_read(
 
 		goto on_error;
 	}
-	if( name_to_id_map_class_identifiers_data == NULL )
-	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
-		 LIBCERROR_RUNTIME_ERROR_VALUE_MISSING,
-		 "%s: missing name to id map class identifiers data.",
-		 function );
-
-		goto on_error;
-	}
-	if( ( name_to_id_map_class_identifiers_data_size == 0 )
-	 || ( name_to_id_map_class_identifiers_data_size > (size64_t) SSIZE_MAX ) )
+	if( (name_to_id_map_class_identifiers_data_size > (size64_t) SSIZE_MAX ) )
 	{
 		libcerror_error_set(
 		 error,
@@ -660,7 +648,7 @@ int libpff_name_to_id_map_entry_read(
 
 		return( -1 );
 	}
-	if( ( name_to_id_map_class_identifiers_data_size < 16 )
+	if( ( name_to_id_map_class_identifiers_data_size < 0 )
 	 || ( name_to_id_map_class_identifiers_data_size > (size_t) SSIZE_MAX ) )
 	{
 		libcerror_error_set(


### PR DESCRIPTION
Two fixes for what I think are upstream issues.
The first is related to PSTs with [name-to-id maps](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/e17e195d-0454-4b9b-b398-c9127a26a678) that don't have a GUID stream or an Entry stream. I don't think there is any reason to require these to be present or non-empty - in particular, the documentation indicates that a minimal name-to-id map only contains one property (https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/5161fee7-42b1-4790-8337-411892b0032c), so it can reasonably not have the streams at all.
The second is related to an upstream bug where a return value is getting incorrectly reused, PR here: https://github.com/libyal/libpff/pull/133