### PR TITLE
Publish wheels for python3.12

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -3,6 +3,11 @@ on: [push]
 permissions: read-all
 jobs:
   build_wheel:
+    strategy:
+      matrix:
+        python-version:
+          - 3.9.20
+          - 3.12.6
     runs-on: [self-hosted, libpff]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -14,11 +19,11 @@ jobs:
         ./synclibs.sh --use-head && ./autogen.sh && ./configure && make sources >/dev/null
     - name: Install Python
       run: |
-        uv python install 3.9.20
+        uv python install ${{ matrix.python-version }}
     - name: Create virtual environment
       run: |
         rm -rf venv
-        uv venv --python 3.9.20 venv
+        uv venv --python ${{ matrix.python-version }} venv
         echo "$(pwd)/venv/bin" >> $GITHUB_PATH
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -12,14 +12,17 @@ jobs:
     - name: Prepare build
       run: |
         ./synclibs.sh --use-head && ./autogen.sh && ./configure && make sources >/dev/null
+    - name: Install Python
+      run: |
+        uv python install 3.9.20
     - name: Create virtual environment
       run: |
         rm -rf venv
-        python3 -m venv venv
+        uv venv --python 3.9.20 venv
         echo "$(pwd)/venv/bin" >> $GITHUB_PATH
     - name: Install Python dependencies
       run: |
-        python3 -m pip install \
+        uv pip install \
           'build' \
           'mypy' \
           'setuptools>=65' \
@@ -27,13 +30,13 @@ jobs:
     - name: Build libpff-python wheel
       run: |
         python3 -m build --no-isolation --outdir=dist --wheel
-        python3 -m pip install --no-index --find-links=dist libpff-python
+        uv pip install --no-index --find-links=dist libpff-python
         python3 tests/runtests.py
     - name: Build pypff-stubs wheel
       working-directory: stubs
       run: |
         python3 -m build --outdir=dist --wheel
-        python3 -m pip install --no-index --find-links=dist pypff-stubs
+        uv pip install --no-index --find-links=dist pypff-stubs
         mypy --strict -c 'import pypff; reveal_type(pypff.file)'
     - name: Upload wheels
       run: |


### PR DESCRIPTION
In order to start the upgrade to python3.12 in the servers repo, we need to have `*-cp312-*` wheels available :)