### PR TITLE
ci: Bump `libpff` wheel version (to trigger rebuild)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.71])
 
 AC_INIT(
  [libpff],
- [20240608],
+ [20240608.1],
  [joachim.metz@gmail.com])
 
 AC_CONFIG_SRCDIR(


### PR DESCRIPTION
There are no code changes here, but this should get kicked off against runners on Ubuntu 20.04.  See https://github.com/Everlaw/servers/pull/38787.