### PR TITLE
dev: Add a basic `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @Everlaw/developer-experience-squad


### PR DESCRIPTION
Currently, we have Renovate configured to open PRs against this repo, but nobody is actually ever reviewing them...

In the future, it would be nice to designate some other group of people to review the "code" here, but we need *some* catch-all for now.