### PR TITLE
renovate: Update GitHub Actions via semver tags *with* SHAs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,5 +5,18 @@
     "schedule:weekly"
   ],
   "timezone": "America/Los_Angeles",
-  "includePaths": [".github/**"]
+  "includePaths": [".github/**"],
+  "packageRules": [
+    // Pin GitHub Actions to immutable SHAs.
+    {
+      matchDepTypes: ["action"],
+      pinDigests: true,
+    },
+    // Annotate GitHub Actions SHAs with a SemVer version.
+    {
+      extends: ["helpers:pinGitHubActionDigests"],
+      extractVersion: "^(?<version>v?\\d+\\.\\d+\\.\\d+)$",
+      versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
+    },
+  ],
 }

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -10,7 +10,7 @@ jobs:
           - 3.12.6
     runs-on: [self-hosted, libpff]
     steps:
-    - uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Download test data
       run: |
         if test -x "synctestdata.sh"; then ./synctestdata.sh; fi


### PR DESCRIPTION
This is the equivalent of https://github.com/Everlaw/fastText/pull/7.