### PR TITLE
Fix `license_files`

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -6,8 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.9.20
-          - 3.12.6
+          - 3.12.11
     runs-on: [self-hosted, libpff]
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/setup.cfg.in
+++ b/setup.cfg.in
@@ -7,7 +7,7 @@ long_description_content_type = text/plain
 author = Joachim Metz
 author_email = joachim.metz@gmail.com
 license = GNU Lesser General Public License v3 or later (LGPLv3+)
-license_files = COPYING COPYING.LESSER
+license_files = COPYING, COPYING.LESSER
 classifiers =
   Development Status :: 3 - Alpha
   Programming Language :: Python


### PR DESCRIPTION
Before this, our [CI runs](https://github.com/Everlaw/libpff/actions/runs/19642110034/job/56249042533#step:8:8) were spitting out deprecation warnings like

    /__work/libpff/libpff/venv/lib/python3.12/site-packages/setuptools/dist.py:483: SetuptoolsDeprecationWarning: Please provide a valid glob pattern.
    !!
            ********************************************************************************
            Pattern 'COPYING COPYING.LESSER' contains invalid characters.
            By 2026-Mar-20, you need to update your project and remove deprecated calls
            or your builds will no longer be supported.
            See https://packaging.python.org/en/latest/specifications/glob-patterns/ for details.
            ********************************************************************************
    !!
      for path in sorted(cls._find_pattern(pattern, enforce_match))

According to https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata, this is a "list-comma" field, which is a "dangling list or string of comma-separated values".

