### PR TITLE
Bump libcpath version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.71])
 
 AC_INIT(
  [libpff],
- [20240608.1],
+ [20240608.2],
  [joachim.metz@gmail.com])
 
 AC_CONFIG_SRCDIR(

--- a/stubs/pyproject.toml
+++ b/stubs/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "setuptools.build_meta"
 name = "pypff-stubs"
 # The major version should match the version in `configure.ac`'s `AC_INIT`
 # with the minor version incremented as needed for new changes.
-version = "20240608.2"
+version = "20240608.3"
 requires-python = ">=3.9"

--- a/synclibs.sh
+++ b/synclibs.sh
@@ -50,7 +50,7 @@ do
             LATEST_TAG="20240414";
 	elif test ${LOCAL_LIB} = "libcpath";
 	then
-            LATEST_TAG="20240414";
+            LATEST_TAG="20260520";
 	elif test ${LOCAL_LIB} = "libcsplit";
 	then
             LATEST_TAG="20240414";


### PR DESCRIPTION
The previous tag no longer exists, so we need to bump the version for the build to succeed.